### PR TITLE
Handle 'shasum_unavailable' flag in registry dist metadata

### DIFF
--- a/lib/cache/add-named.js
+++ b/lib/cache/add-named.js
@@ -207,9 +207,9 @@ function addNameVersion (name, v, data, cb) {
         }
         tb = url.format(tb)
 
-        // Only add non-shasum'ed packages if --forced. Only ancient things
-        // would lack this for good reasons nowadays.
-        if (!dist.shasum && !npm.config.get('force')) {
+        // Only add non-shasum'ed packages if --forced or 'shasum_unavailable' is true.
+        // Only ancient things would lack this for good reasons nowadays.
+        if (!dist.shasum_unavailable && !dist.shasum && !npm.config.get('force')) {
           return cb(new Error('package lacks shasum: ' + packageId(data)))
         }
 


### PR DESCRIPTION
This bypasses the `package lacks shasum` error if the registry has explicitly set the `shasum_unavailable` to true.
This allows registries to override the need to compute sha1 checksums for each package and version.
Which in turn means the registry does not need to host the dist tarball files for every package in the registry.
